### PR TITLE
add build dependencies for travis-ci explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ script: make
 compiler:
   - clang
   - gcc
+addons:
+  apt:
+    packages:
+      - libxfixes-dev
+      - mesa-common-dev
+      - libgl1-mesa-dev


### PR DESCRIPTION
Apparently travis-ci requires these now