### PR TITLE
patch up things to load raising the bar: redux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,19 @@ jobs:
     - name: Build
       working-directory: ${{ runner.workspace }}/build
       run: cmake --build . --config Release
-    - name: prepare release archive
-      if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/v')
+    - name: Prepare release archive
+      if: matrix.os == 'windows-latest'
       run: |
-        cmake -E make_directory ${{ runner.workspace }}/OpenSource-windows
-        cmake -E copy ${{ github.workspace }}/misc/hl1.cfg ${{ github.workspace }}/misc/hl2.cfg ${{ github.workspace }}/misc/hl2eps.cfg ${{ github.workspace }}/misc/hl1.bat ${{ github.workspace }}/misc/hl2.bat ${{ github.workspace }}/misc/hl2eps.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-windows
-        powershell Compress-Archive ${{ runner.workspace }}/OpenSource-windows/* ${{ runner.workspace }}/OpenSource-windows.zip
-    - name: GH Release
+        cmake -E make_directory ${{ runner.workspace }}/OpenSource-win64
+        cmake -E copy ${{ github.workspace }}/misc/hl1.cfg ${{ github.workspace }}/misc/hl2.cfg ${{ github.workspace }}/misc/hl2eps.cfg ${{ github.workspace }}/misc/hl1.bat ${{ github.workspace }}/misc/hl2.bat ${{ github.workspace }}/misc/hl2eps.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64
+        powershell Compress-Archive ${{ runner.workspace }}/OpenSource-win64/* ${{ runner.workspace }}/OpenSource-win64.zip
+    - name: Upload artifacts
+      if: matrix.os == 'windows-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Windows amd64
+        path: ${{ runner.workspace }}/OpenSource-win64.zip
+    - name: Make GitHub release if tagged
       if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v0.1.5
       env:
@@ -50,4 +56,4 @@ jobs:
         prerelease: true # optional
         # Newline-delimited list of path globs for asset files to upload
         # TODO prepare proper zip with useful things
-        files: ${{ runner.workspace }}/OpenSource-windows.zip
+        files: ${{ runner.workspace }}/OpenSource-win64.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         cmake -E make_directory ${{ runner.workspace }}/OpenSource-win64
-        cmake -E copy ${{ github.workspace }}/misc/hl1.cfg ${{ github.workspace }}/misc/hl2.cfg ${{ github.workspace }}/misc/hl2eps.cfg ${{ github.workspace }}/misc/hl1.bat ${{ github.workspace }}/misc/hl2.bat ${{ github.workspace }}/misc/hl2eps.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64
+        cmake -E copy ${{ github.workspace }}/misc/*.cfg ${{ github.workspace }}/misc/*.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64
         powershell Compress-Archive ${{ runner.workspace }}/OpenSource-win64/* ${{ runner.workspace }}/OpenSource-win64.zip
     - name: Upload artifacts
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         cmake -E make_directory ${{ runner.workspace }}/OpenSource-win64
-        cmake -E copy ${{ github.workspace }}/misc/*.cfg ${{ github.workspace }}/misc/*.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64
+        cmake -E copy ${{ github.workspace }}/misc/hl1.cfg ${{ github.workspace }}/misc/hl2.cfg ${{ github.workspace }}/misc/hl2eps.cfg ${{ github.workspace }}/misc/hl1.bat ${{ github.workspace }}/misc/hl2.bat ${{ github.workspace }}/misc/hl2eps.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64
         powershell Compress-Archive ${{ runner.workspace }}/OpenSource-win64/* ${{ runner.workspace }}/OpenSource-win64.zip
     - name: Upload artifacts
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: actions/upload-artifact@v3
       with:
-        name: Windows amd64
-        path: ${{ runner.workspace }}/OpenSource-win64.zip
+        name: OpenSource-win64
+        path: ${{ runner.workspace }}/OpenSource-win64
     - name: Make GitHub release if tagged
       if: matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v0.1.5

--- a/misc/rtbr.cfg
+++ b/misc/rtbr.cfg
@@ -1,0 +1,22 @@
+gamedir "Source SDK Base 2013 Singleplayer"
+vpk "hl2/hl2_textures_dir.vpk"
+vpk "hl2/hl2_misc_dir.vpk"
+vpk "episodic/ep1_pak_dir.vpk"
+vpk "ep2/ep2_pak_dir.vpk"
+vpk "sourcetest/sourcetest_pak_dir.vpk"
+vpk "platform/platform_misc_dir.vpk"
+dir ""
+
+gamedir "../sourcemods/RaisingTheBarRedux_div2"
+vpk "mapbase/mapbase_shared/shared_content_v7_0_dir.vpk"
+vpk "mapbase/mapbase_hl2/hl2_materials_dir.vpk"
+vpk "mapbase/mapbase_hl2/lostcoast_materials_dir.vpk"
+vpk "mapbase/mapbase_hl2/hl2_scenes_dir.vpk"
+vpk "mapbase/mapbase_hl2/hl2_mapbase_content_dir.vpk"
+vpk "mapbase/mapbase_episodic/episodic_mapbase_content_dir.vpk"
+vpk "mapbase/mapbase_episodic/episodic_scenes_dir.vpk"
+vpk "mapbase/mapbase_episodic/episodic_materials_dir.vpk"
+dir ""
+
+max_maps 100
+map rtbr_d1_trainstation01

--- a/src/OpenSource.c
+++ b/src/OpenSource.c
@@ -16,7 +16,7 @@
 #endif
 
 static char persistent_data[128*1024*1024];
-static char temp_data[128*1024*1024];
+static char temp_data[256*1024*1024];
 
 static struct Stack stack_temp = {
 	.storage = temp_data,

--- a/src/material.c
+++ b/src/material.c
@@ -125,9 +125,12 @@ static VMFAction materialParserCallback(VMFState *state, VMFEntryType entry, con
 			} else {
 				ctx->shader = kv->key;
 				if (strncasecmp("unlitgeneric", kv->key.str, kv->key.length) == 0
+					|| strncasecmp("SDK_UnlitGeneric", kv->key.str, kv->key.length) == 0
 					|| strncasecmp("sky", kv->key.str, kv->key.length) == 0)
 					ctx->mat->shader = MShader_UnlitGeneric;
 				else if (strncasecmp("lightmappedgeneric", kv->key.str, kv->key.length) == 0
+					|| strncasecmp("SDK_LightmappedGeneric", kv->key.str, kv->key.length) == 0
+					|| strncasecmp("sdk_worldvertextransition", kv->key.str, kv->key.length) == 0
 					|| strncasecmp("worldvertextransition", kv->key.str, kv->key.length) == 0)
 					ctx->mat->shader = MShader_LightmappedGeneric;
 				else


### PR DESCRIPTION
Changes:
- Added RTB:R config with default dir layout
- Added Source SDK materials
- Added uploading win64 build results as artifacts for CI builds. Now PR builds can be downloaded and tested.

Some of the textures will still be missing on Linux due to case-sensitive filesystem. Seems to work fine on Windows.

fixes #80 