### PR TITLE
make it always write all log messages into OpenSource.log

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,12 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         cmake -E make_directory ${{ runner.workspace }}/OpenSource-win64
-        cmake -E copy ${{ github.workspace }}/misc/hl1.cfg ${{ github.workspace }}/misc/hl2.cfg ${{ github.workspace }}/misc/hl2eps.cfg ${{ github.workspace }}/misc/hl1.bat ${{ github.workspace }}/misc/hl2.bat ${{ github.workspace }}/misc/hl2eps.bat ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64
+        cmake -E copy ${{ runner.workspace }}/build/Release/OpenSource.exe ${{ runner.workspace }}/OpenSource-win64/
+        cmake -E copy ${{ github.workspace }}/README.md ${{ runner.workspace }}/OpenSource-win64/
+        cmake -E copy ${{ github.workspace }}/misc/hl1.cfg ${{ github.workspace }}/misc/hl1.bat ${{ runner.workspace }}/OpenSource-win64/
+        cmake -E copy ${{ github.workspace }}/misc/hl2.cfg ${{ github.workspace }}/misc/hl2.bat ${{ runner.workspace }}/OpenSource-win64/
+        cmake -E copy ${{ github.workspace }}/misc/hl2eps.cfg ${{ github.workspace }}/misc/hl2eps.bat ${{ runner.workspace }}/OpenSource-win64/
+        cmake -E copy ${{ github.workspace }}/misc/portal.cfg ${{ github.workspace }}/misc/portal.bat ${{ runner.workspace }}/OpenSource-win64/
         powershell Compress-Archive ${{ runner.workspace }}/OpenSource-win64/* ${{ runner.workspace }}/OpenSource-win64.zip
     - name: Upload artifacts
       if: matrix.os == 'windows-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tags
 *.opendb
 *.db
 *.user
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,19 @@ add_subdirectory(src/atto)
 
 set(SOURCES
 	src/OpenSource.c
-	src/bsp.c
 	src/atlas.c
-	src/filemap.c
+	src/bsp.c
+	src/cache.c
 	src/camera.c
 	src/collection.c
-	src/vmfparser.c
-	src/material.c
-	src/texture.c
-	src/cache.c
 	src/dxt.c
-	src/render.c
+	src/filemap.c
+	src/log.c
+	src/material.c
 	src/profiler.c
+	src/render.c
+	src/texture.c
+	src/vmfparser.c
 )
 
 set(HEADERS
@@ -37,6 +38,7 @@ set(HEADERS
 	src/etcpack.h
 	src/filemap.h
 	src/libc.h
+	src/log.h
 	src/material.h
 	src/mempools.h
 	src/profiler.h

--- a/misc/portal.bat
+++ b/misc/portal.bat
@@ -1,0 +1,1 @@
+OpenSource.exe portal.cfg

--- a/src/OpenSource.c
+++ b/src/OpenSource.c
@@ -502,7 +502,7 @@ static VMFAction configLandmarkCallback(VMFState *state, VMFEntryType entry, con
 		state->callback = configPatchCallback;
 		break;
 	default:
-		PRINTF("%s: Unexpected entry %d", __FUNCTION__, entry);
+		PRINTF("%s: Unexpected entry %d", __func__, entry);
 		return VMFAction_SemanticError;
 	}
 
@@ -519,13 +519,13 @@ static VMFAction configMapCallback(VMFState *state, VMFEntryType entry, const VM
 		} else if (strncasecmp("offset", kv->key.str, kv->key.length) == 0) {
 			cfg->map_offset = kv->value;
 		} else {
-			PRINTF("%s: Unexpected key \"" PRI_SV "\"", __FUNCTION__, PRI_SVV(kv->key));
+			PRINTF("%s: Unexpected key \"" PRI_SV "\"", __func__, PRI_SVV(kv->key));
 			return VMFAction_SemanticError;
 		}
 		break;
 	case VMFEntryType_SectionClose:
 		if (cfg->map_name.length < 1) {
-			PRINTF("%s: Invalid map name \"" PRI_SV "\"", __FUNCTION__, PRI_SVV(cfg->map_name));
+			PRINTF("%s: Invalid map name \"" PRI_SV "\"", __func__, PRI_SVV(cfg->map_name));
 			return VMFAction_SemanticError;
 		}
 		Map *m = opensrcAllocMap(cfg->map_name);
@@ -542,7 +542,7 @@ static VMFAction configMapCallback(VMFState *state, VMFEntryType entry, const VM
 		state->callback = configReadCallback;
 		break;
 	default:
-		PRINTF("%s: Unexpected entry %d", __FUNCTION__, entry);
+		PRINTF("%s: Unexpected entry %d", __func__, entry);
 		return VMFAction_SemanticError;
 	}
 
@@ -555,7 +555,7 @@ static VMFAction configPatchCallback(VMFState *state, VMFEntryType entry, const 
 	switch (entry) {
 	case VMFEntryType_SectionOpen:
 		if (kv->key.length < 1) {
-			PRINTF("%s: Unexpected section \"" PRI_SV "\"", __FUNCTION__, PRI_SVV(kv->key));
+			PRINTF("%s: Unexpected section \"" PRI_SV "\"", __func__, PRI_SVV(kv->key));
 			return VMFAction_SemanticError;
 		}
 		cfg->map_name = kv->key;
@@ -564,7 +564,7 @@ static VMFAction configPatchCallback(VMFState *state, VMFEntryType entry, const 
 	case VMFEntryType_SectionClose:
 		return VMFAction_Exit;
 	default:
-		PRINTF("%s: Unexpected entry %d", __FUNCTION__, entry);
+		PRINTF("%s: Unexpected entry %d", __func__, entry);
 		return VMFAction_SemanticError;
 	}
 
@@ -595,7 +595,7 @@ static VMFAction configReadCallback(VMFState *state, VMFEntryType entry, const V
 			// FIXME null-terminate
 			g.R = (float)atof(kv->value.str);
 		} else {
-			PRINTF("%s: Unexpected key \"" PRI_SV "\"", __FUNCTION__, PRI_SVV(kv->key));
+			PRINTF("%s: Unexpected key \"" PRI_SV "\"", __func__, PRI_SVV(kv->key));
 			return VMFAction_SemanticError;
 		}
 		break;
@@ -606,12 +606,12 @@ static VMFAction configReadCallback(VMFState *state, VMFEntryType entry, const V
 			cfg->map_name.length = cfg->map_offset.length = 0;
 			state->callback = configMapCallback;
 		} else {
-			PRINTF("%s: Unexpected section \"" PRI_SV "\"", __FUNCTION__, PRI_SVV(kv->key));
+			PRINTF("%s: Unexpected section \"" PRI_SV "\"", __func__, PRI_SVV(kv->key));
 			return VMFAction_SemanticError;
 		}
 		break;
 	default:
-		PRINTF("%s: Unexpected entry %d", __FUNCTION__, entry);
+		PRINTF("%s: Unexpected entry %d", __func__, entry);
 		return VMFAction_SemanticError;
 	}
 

--- a/src/OpenSource.c
+++ b/src/OpenSource.c
@@ -596,7 +596,8 @@ static VMFAction configReadCallback(VMFState *state, VMFEntryType entry, const V
 			g.R = (float)atof(kv->value.str);
 		} else {
 			PRINTF("%s: Unexpected key \"" PRI_SV "\"", __func__, PRI_SVV(kv->key));
-			return VMFAction_SemanticError;
+			// TODO return VMFAction_SemanticError;
+			return VMFAction_Exit;
 		}
 		break;
 	case VMFEntryType_SectionOpen:
@@ -642,6 +643,9 @@ static int configReadFile(const char *cfgfile) {
 	};
 
 	aFileClose(&file);
+
+	// TODO remove
+	PRINTF("Parsing config file \"%s\" (%d):\n```\n%.*s\n```", cfgfile, pstate.data.length, pstate.data.length, pstate.data.str);
 
 	int result = VMFResult_Success == vmfParse(&pstate);
 

--- a/src/common.h
+++ b/src/common.h
@@ -3,10 +3,16 @@
 
 #define STR1(m) #m
 #define STR(m) STR1(m)
-#define PRINTF(fmt, ...) fprintf(stderr, __FILE__ ":" STR(__LINE__) ": " fmt "\n", __VA_ARGS__)
-#define PRINT(msg) fprintf(stderr, __FILE__ ":" STR(__LINE__) ": %s\n", msg)
 
-#define ASSERT(cond) if (!(cond)){PRINTF("%s failed", #cond); abort();}
+#ifdef _MSC_VER
+// MSVC compiler
+#define PRINTF_ARG(fmt) _Printf_format_string_ fmt
+#define PRINTF_ATTR(fmt_index, vargs_index)
+#else
+// gcc-compatible
+#define PRINTF_ARG(fmt) fmt
+#define PRINTF_ATTR(fmt_index, vargs_index) __attribute__((format(printf, fmt_index, vargs_index)))
+#endif
 
 #define COUNTOF(a) (sizeof(a) / sizeof(*(a)))
 

--- a/src/filemap.c
+++ b/src/filemap.c
@@ -1,5 +1,6 @@
 #include "filemap.h"
 #include "common.h"
+#include "log.h"
 
 #ifndef _WIN32
 #include <sys/types.h>

--- a/src/log.c
+++ b/src/log.c
@@ -1,4 +1,3 @@
-#pragma once
 #include "log.h"
 
 #include <stdio.h>

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,32 @@
+#pragma once
+#include "log.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+
+static struct {
+	FILE *logfile;
+} glog = {0};
+
+void logOpen(const char *logfile) {
+	glog.logfile = fopen(logfile, "w");
+}
+
+void logClose(void) {
+	fclose(glog.logfile);
+}
+
+void logPrintf(const char *format, ...) {
+	va_list args;
+	va_start(args, format);
+
+	if (glog.logfile) {
+		va_list args_copy;
+		va_copy(args_copy, args);
+		vfprintf(glog.logfile, format, args_copy);
+		va_end(args_copy);
+	}
+
+	vfprintf(stderr, format, args);
+	va_end(args);
+}

--- a/src/log.h
+++ b/src/log.h
@@ -3,7 +3,7 @@
 void logOpen(const char *logfile);
 void logClose(void);
 
-void logPrintf(PRINTF_ARG(const char *format), ...) PRINTF_ATTR(0, 1);
+void logPrintf(PRINTF_ARG(const char *format), ...) PRINTF_ATTR(1, 2);
 
 #define PRINTF(fmt, ...) logPrintf(__FILE__ ":" STR(__LINE__) ": " fmt "\n", __VA_ARGS__)
 #define PRINT(msg) logPrintf(__FILE__ ":" STR(__LINE__) ": %s\n", msg)

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,11 @@
+#include "common.h"
+
+void logOpen(const char *logfile);
+void logClose(void);
+
+void logPrintf(PRINTF_ARG(const char *format), ...) PRINTF_ATTR(0, 1);
+
+#define PRINTF(fmt, ...) logPrintf(__FILE__ ":" STR(__LINE__) ": " fmt "\n", __VA_ARGS__)
+#define PRINT(msg) logPrintf(__FILE__ ":" STR(__LINE__) ": %s\n", msg)
+
+#define ASSERT(cond) if (!(cond)){PRINTF("%s failed", #cond); abort();}

--- a/src/mempools.h
+++ b/src/mempools.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "common.h"
+#include "log.h"
 #include <stddef.h>
 
 typedef struct Stack {

--- a/src/vmfparser.c
+++ b/src/vmfparser.c
@@ -1,5 +1,5 @@
 #include "vmfparser.h"
-#include "libc.h"
+#include "log.h"
 
 typedef enum {
 	VMFTokenType_End,


### PR DESCRIPTION
Also, make config parsing errors more verbose

This is to aid #83 